### PR TITLE
addressed and fixed an issue where when getting products a error was sent saying ZeroDivisionError

### DIFF
--- a/bangazonapi/models/product.py
+++ b/bangazonapi/models/product.py
@@ -7,7 +7,6 @@ from .productcategory import ProductCategory
 from .orderproduct import OrderProduct
 from .productrating import ProductRating
 
-
 class Product(SafeDeleteModel):
 
     _safedelete_policy = SOFT_DELETE
@@ -61,8 +60,10 @@ class Product(SafeDeleteModel):
         total_rating = 0
         for rating in ratings:
             total_rating += rating.rating
-
-        avg = total_rating / len(ratings)
+        try:
+            avg = total_rating / len(ratings)
+        except ZeroDivisionError:
+            avg = total_rating
         return avg
 
     class Meta:

--- a/bangazonapi/models/productrating.py
+++ b/bangazonapi/models/productrating.py
@@ -7,7 +7,7 @@ class ProductRating(models.Model):
 
     product = models.ForeignKey("Product", on_delete=models.CASCADE, related_name="ratings")
     customer = models.ForeignKey(Customer, on_delete=models.CASCADE)
-    rating = models.IntegerField(validators=[MinValueValidator(0), MaxValueValidator(5)])
+    rating = models.IntegerField(validators=[MinValueValidator(1), MaxValueValidator(5)])
 
 class Meta:
     verbose_name = ("productrating")

--- a/bangazonapi/models/productrating.py
+++ b/bangazonapi/models/productrating.py
@@ -7,7 +7,7 @@ class ProductRating(models.Model):
 
     product = models.ForeignKey("Product", on_delete=models.CASCADE, related_name="ratings")
     customer = models.ForeignKey(Customer, on_delete=models.CASCADE)
-    rating = models.IntegerField(validators=[MinValueValidator(1), MaxValueValidator(5)])
+    rating = models.IntegerField(validators=[MinValueValidator(0), MaxValueValidator(5)])
 
 class Meta:
     verbose_name = ("productrating")


### PR DESCRIPTION
When trying to retrieve products an error was sent back saying ZeroDivisionError: cannot divide by zero. Error was based off of average ratings of products.

## Changes

- Did a Try block first to test the errors
- did an except block to handle this error for rating to be sent through even if it is zero

## Testing

Description of how to test code...

- [ ] Run migrations
- [ ] Run test suite
- [ ] Seed database


## Related Issues

-fixes #11 