### PR TITLE
in views/profile.py  changed open_order

### DIFF
--- a/bangazonapi/views/order.py
+++ b/bangazonapi/views/order.py
@@ -104,7 +104,7 @@ class Orders(ViewSet):
         """
         customer = Customer.objects.get(user=request.auth.user)
         order = Order.objects.get(pk=pk, customer=customer)
-        order.payment_type = request.data["payment_type"]
+        order.payment_type =  Payment.objects.get(pk=request.data["payment_type"])
         order.save()
 
         return Response({}, status=status.HTTP_204_NO_CONTENT)

--- a/bangazonapi/views/profile.py
+++ b/bangazonapi/views/profile.py
@@ -206,8 +206,8 @@ class Profile(ViewSet):
             """
 
             try:
-                open_order = Order.objects.get(customer=current_user)
-                print(open_order)
+                open_order = Order.objects.get(
+                    customer=current_user, payment_type__isnull=True)
             except Order.DoesNotExist as ex:
                 open_order = Order()
                 open_order.created_date = datetime.datetime.now()


### PR DESCRIPTION
when adding item to cart wasn't creating a new order was just adding to closed order.

## Changes

- in `views/order.py` under `def update` changed `order.payment_type` from `request.data["payment_type"]` to 
`Payment.objects.get(pk=request.data["payment_type"])` because it was not getting payment type object

- in `views/profile.py` under `def cart` where `if method == POST` is added `payment_type__isnull=True`
this prevents the item from being added to the previous order and creates a new order if there is a payment type present on the order.

## Requests / Responses

**Request**

POST `/profile/cart` adds a product to an order

```json
{
    "product_id": 88
}
```

**Response**

HTTP/1.1 201 OK

```json
{
    "id": 12,
    "product": {
        "id": 1,
        "name": "Optima",
        "price": 1655.15,
        "number_sold": 1,
        "description": "2008 Kia",
        "quantity": 3,
        "created_date": "2019-05-21",
        "location": "Onguday",
        "image_path": null,
        "average_rating": 0
    }
}
```

## Testing

Description of how to test code...

- [ ] open postman and authenticate
- [ ] add item to cart.
- [ ] GET orders to see if a new order was created


## Related Issues

- Fixes #2 
