### PR TITLE
Jm not getting profile

### DIFF
--- a/bangazonapi/views/profile.py
+++ b/bangazonapi/views/profile.py
@@ -61,7 +61,7 @@ class Profile(ViewSet):
             }
         """
         try:
-            current_user = Customer.objects.get(user__id=4)
+            current_user = Customer.objects.get(user__id=request.auth.user_id)
             serializer = ProfileSerializer(current_user, many=False, context={'request': request})
             return Response(serializer.data)
         except Exception as ex:
@@ -302,7 +302,7 @@ class UserSerializer(serializers.HyperlinkedModelSerializer):
     """
     class Meta:
         model = User
-        fields = ('first_name', 'last_name', 'email')
+        fields = ('id', 'first_name', 'last_name', 'email')
         depth = 1
 
 


### PR DESCRIPTION
when getting current users profile it was only trying to grab one specific users profile

## Changes

- in `views/profile.py` on `UserSerializer` added 'id' to fields
- in the `def list` changed `current_user = Customer.objects.get(user__id=4)` to `current_user = Customer.objects.get(user__id=request.auth.user_id)`

the first change will get the current users id while the 2nd change gets the current users id from the request to retrieve the actual current user's profile

**Request**

GET `/profile` gets current user's profile

**Response**

HTTP/1.1 201 OK

```json
{
    "id": 7,
    "url": "http://localhost:8000/customers/7",
    "user": {
        "id": 8,
        "first_name": "Brenda",
        "last_name": "Long",
        "email": "brenda@brendalong.com"
    },
    "phone_number": "555-1212",
    "address": "100 Indefatiguable Way",
    "payment_types": [
        {
            "url": "http://localhost:8000/paymenttypes/3",
            "deleted": null,
            "merchant_name": "Visa",
            "account_number": "fj0398fjw0g89434",
            "expiration_date": "2020-03-01",
            "create_date": "2019-03-11",
            "customer": "http://localhost:8000/customers/7"
        }
    ]
}
```

## Testing

Description of how to test code...

- [ ] in postman run a GET on `http://localhost:8000/profile`
- [ ] check current logged in user to see if information matches.


## Related Issues

- Fixes #4 