### PR TITLE
sold_filter had less than and not greater than

### DIFF
--- a/bangazonapi/views/product.py
+++ b/bangazonapi/views/product.py
@@ -266,7 +266,7 @@ class Products(ViewSet):
 
         if number_sold is not None:
             def sold_filter(product):
-                if product.number_sold <= int(number_sold):
+                if product.number_sold >= int(number_sold):
                     return True
                 return False
 


### PR DESCRIPTION
filtering for number of products sold was no filtering correctly

## Changes

- in `views/product.py` the `sold_filter` under list was showing less than number sold and not greater than which was not displaying the proper products that had been sold at or more than the specified number

## Requests / Responses

**Request**

GET `/products?number_sold=2` gets products that have been sold 2 or more times 


**Response**

HTTP/1.1 200 OK

```json
{
        "id": 50,
        "name": "Escalade EXT",
        "price": 926.92,
        "number_sold": 2,
        "description": "2008 Cadillac",
        "quantity": 2,
        "created_date": "2019-02-01",
        "location": "Lokavec",
        "image_path": null,
        "average_rating": 3.25
    },
    {
        "id": 52,
        "name": "900",
        "price": 1296.98,
        "number_sold": 1,
        "description": "1987 Saab",
        "quantity": 2,
        "created_date": "2019-03-19",
        "location": "Vratsa",
        "image_path": null,
        "average_rating": 0
    },
```

## Testing

Description of how to test code...

- [ ] in post man do a GET call for `http://localhost:8000/products?number_sold=1`
- [ ] see if only products that had been sold 2 or more times are listed


## Related Issues

- Fixes #5 