### PR TITLE
added a line to destroy in lineitem so it'll remove the item

### DIFF
--- a/bangazonapi/views/lineitem.py
+++ b/bangazonapi/views/lineitem.py
@@ -77,7 +77,8 @@ class LineItems(ViewSet):
         try:
             customer = Customer.objects.get(user=request.auth.user)
             order_product = OrderProduct.objects.get(pk=pk, order__customer=customer)
-
+            order_product.delete()
+            
             return Response({}, status=status.HTTP_204_NO_CONTENT)
 
         except OrderProduct.DoesNotExist as ex:


### PR DESCRIPTION
adds a line to `views/lineitem.py` that deletes the specified item

## Changes

- wrote a line that will delete the lineitem specified in `views/lineitem.py` line 81


**Request**

DELETE /lineitems/nDeletes line item from cart

**Response**

HTTP/1.1 200 OK

```json
{
        "id": 11,
        "url": "http://localhost:8000/orders/11",
        "created_date": "2021-02-13",
        "payment_type": null,
        "customer": "http://localhost:8000/customers/7",
        "lineitems": [
            {
                "id": 12,
                "product": {
                    "id": 1,
                    "name": "Optima",
                    "price": 1655.15,
                    "number_sold": 1,
                    "description": "2008 Kia",
                    "quantity": 3,
                    "created_date": "2019-05-21",
                    "location": "Onguday",
                    "image_path": null,
                    "average_rating": 0
                }
            }
        ]
    }
```

## Testing

- [ ] add a item to the cart
- [ ] run a DELETE call on `/lineitems/n` with proper product id
- [ ] get cart to ensure item was deleted


## Related Issues

- Fixes #6 