### PR TITLE
created_date and expiration_date were switched in view/paymenttype.py

### DIFF
--- a/bangazonapi/views/paymenttype.py
+++ b/bangazonapi/views/paymenttype.py
@@ -34,8 +34,8 @@ class Payments(ViewSet):
         new_payment = Payment()
         new_payment.merchant_name = request.data["merchant_name"]
         new_payment.account_number = request.data["account_number"]
-        new_payment.expiration_date = request.data["create_date"]
-        new_payment.create_date = request.data["expiration_date"]
+        new_payment.create_date = request.data["create_date"]
+        new_payment.expiration_date = request.data["expiration_date"]
         customer = Customer.objects.get(user=request.auth.user)
         new_payment.customer = customer
         new_payment.save()


### PR DESCRIPTION
a fix to paymenttype viewset to have it so the correct expiration date shows in payment types

## Changes

- changed names on lines 37 and 38 in `views/paymenttypes.py` to represent the proper data field

## Requests / Responses

**Request**

GET `/paymenttypes/1` retrieves payment types

**Response**

HTTP/1.1 201 OK

```json
{
    "id": 1,
    "url": "http://localhost:8000/paymenttypes/1",
    "merchant_name": "Visa",
    "account_number": "24ijio68948fj8439",
    "expiration_date": "2020-01-01",
    "create_date": "2019-11-11"
}
```

## Testing

Description of how to test code...

- [ ] do a GET call for a single payment type
- [ ] check expiration date against what customer has

## Related Issues

- Fixes #7 