### PR TITLE
simplified paymenttype filter to one line that filters payment type…

### DIFF
--- a/bangazonapi/views/paymenttype.py
+++ b/bangazonapi/views/paymenttype.py
@@ -81,10 +81,7 @@ class Payments(ViewSet):
         """Handle GET requests to payment type resource"""
         payment_types = Payment.objects.all()
 
-        customer_id = self.request.query_params.get('customer', None)
-
-        if customer_id is not None:
-            payment_types = payment_types.filter(customer__id=customer_id)
+        payment_types = payment_types.filter(customer__id=request.auth.user.id)
 
         serializer = PaymentSerializer(
             payment_types, many=True, context={'request': request})


### PR DESCRIPTION
payment type correctly filters to only show current user payment types

## Changes

- removed lines 84-87 in `views/paymenttypes.py` and made it one line from

**Request**

GET `/paymenttypes` Creates a new product

**Response**

HTTP/1.1 200 OK

```json
[
    {
        "id": 1,
        "url": "http://localhost:8000/paymenttypes/1",
        "merchant_name": "Visa",
        "account_number": "24ijio68948fj8439",
        "expiration_date": "2020-01-01",
        "create_date": "2019-11-11"
    }
]
```

## Testing

Description of how to test code...

- [ ] authenticate
- [ ] create a new payment type
- [ ] use a GET call to get payment types


## Related Issues

- Fixes #8 